### PR TITLE
add macOS Disable System Updates TTP

### DIFF
--- a/ttps/defense-evasion/macos/disable-system-updates/README.md
+++ b/ttps/defense-evasion/macos/disable-system-updates/README.md
@@ -1,0 +1,29 @@
+# macOS Disable System Updates
+
+![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+
+Disable automatic system security updates.
+
+## Arguments
+
+- **cleanup**: When set to true, it will re-enable automatic system security updates.
+
+## Pre-requisites
+
+Ensure that you have the necessary permissions to write to `/Library/Preferences/com.apple.SoftwareUpdate.plist`.
+
+## Examples
+
+Execute defaults to disable macOS system security updates. Once execution is
+complete, this TTP will re-enable automatic system security updates if cleanup is
+set to true:
+
+```bash
+ttpforge run ttps/defense-evasion/macos/disable-system-updates/disable-system-updates.yaml
+```
+
+## Steps
+
+1. **Disable Updates**: Execute defaults to disable automatic system security updates.
+
+1. **Cleanup**: If the `cleanup` argument is set to `true`, execute defaults to enable automatic system security updates.

--- a/ttps/defense-evasion/macos/disable-system-updates/README.md
+++ b/ttps/defense-evasion/macos/disable-system-updates/README.md
@@ -1,6 +1,6 @@
 # macOS Disable System Updates
 
-![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+![Community TTP - VVX7](https://img.shields.io/badge/Community_TTP-green)
 
 Disable automatic system security updates.
 

--- a/ttps/defense-evasion/macos/disable-system-updates/disable-system-updates.yaml
+++ b/ttps/defense-evasion/macos/disable-system-updates/disable-system-updates.yaml
@@ -1,7 +1,7 @@
 ---
 name: Disable system security updates
 description: |
-  This TTP disables the automatic installation of macOS security updates. 
+  This TTP disables the automatic installation of macOS security updates.
 mitre:
   tactics:
     - T0005 Defense Evasion

--- a/ttps/defense-evasion/macos/disable-system-updates/disable-system-updates.yaml
+++ b/ttps/defense-evasion/macos/disable-system-updates/disable-system-updates.yaml
@@ -1,0 +1,24 @@
+---
+name: Disable system security updates
+description: |
+  This TTP disables the automatic installation of macOS security updates. 
+mitre:
+  tactics:
+    - T0005 Defense Evasion
+  techniques:
+    - T1562 Impair Defenses
+  subtechniques:
+    - "T1562.001 Impair Defenses: Disable or Modify Tools"
+
+steps:
+  - name: disable-updates
+    inline: |
+      echo -e "===> Disabling automatic installation of security updates..."
+      sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist CriticalUpdateInstall -bool NO
+      echo "[+] DONE!"
+
+    cleanup:
+      inline: |
+        echo -e "===> Enabling automatic installation of security updates..."
+        sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist CriticalUpdateInstall -bool YES
+        echo "[+] DONE!"


### PR DESCRIPTION
# Proposed Changes

macOS Disable System Updates TTP + readme

I didn't see an example of a TTP that requires admin permissions so I've added one. Currently this TTP assumes the user is a member of sudoers and prompts for their password at run time. Wondering if you had plans to handle this differently.

## Related Issue(s)

n/a

## Testing

Executed on local machine to confirm effects and cleanup.

## Documentation

Included in README.md

## Screenshots/GIFs (optional)

n/a

## Checklist

- [ x ] Ran `mage runprecommit` locally and fixed any issues that arose.
- [ x ] Curated your commit(s) so they are legible and easy to read and understand.
- [ x ] 🚀
