### PR TITLE
Minor bug fix

### DIFF
--- a/ttps/macOS/README.md
+++ b/ttps/macOS/README.md
@@ -182,7 +182,7 @@ ttpforge run ttps/macOS/tcl_load_dylib/tcl_load_dylib.yaml
 - From the root ForgeArmory directory, run:
 
 ```bash
-ttpforge ttps/macOS/mdfind_aws_keys/mdfind_aws_keys.yaml
+ttpforge run ttps/macOS/mdfind_aws_keys/mdfind_aws_keys.yaml
 ```
 
 21. List device configuration profile information for the target host.


### PR DESCRIPTION
# Proposed Changes

Fixed minor bug in the macOS README

## Related Issue(s)

N/A

## Testing

N/A

## Documentation

One of the examples in the macOS TTP README was missing a `run`

## Screenshots/GIFs (optional)

N/A

## Checklist

- [ ] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [x] 🚀
