### PR TITLE
Implemented a pre-commit hook to promote naming consistency across YAML

### DIFF
--- a/.hooks/check-underscores-in-name.sh
+++ b/.hooks/check-underscores-in-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+for file in $(git diff --cached --name-only --diff-filter=ACM); do
+    echo "Checking file: $file"
+
+    base_name=$(basename "$file")
+    dir_name=$(dirname "$file")
+
+    # Check if the base name of the file or directory has an underscore
+    if [[ $base_name == *_* ]]; then
+
+        if [[ "$file" == *.yml ]] || [[ "$file" == *.yaml ]] || {
+                                                                  [[ ! -f "$file" ]] && [[ -d "$file" ]]
+        }; then
+
+            # Replace underscores with dashes using parameter expansion
+            new_name=${base_name//_/-}
+            # Check if the directory name is ".", which represents the root, and adjust accordingly
+            new_path=$([[ "$dir_name" == "." ]] && echo "$new_name" || echo "$dir_name/$new_name")
+
+            # Rename the file or directory and stage the change in Git
+            git mv "$file" "$new_path"
+            git reset HEAD "$file"
+
+            echo "Info: Renamed $file to $new_path"
+        fi
+    else
+        echo "$base_name does not have an underscore."
+    fi
+done
+
+exit 0

--- a/.hooks/tests/check-underscores-in-name.bats
+++ b/.hooks/tests/check-underscores-in-name.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+# Save the initial working directory
+INITIAL_DIR="$(pwd)"
+
+setup() {
+	# Create a temporary directory
+	TEMP_DIR=$(mktemp -d)
+
+	# Change to the temporary directory
+	cd "$TEMP_DIR" || exit
+
+	# Initialize a git repo in the temp directory
+	git init >/dev/null
+
+	# Create test files and directory with underscores
+	touch test_file_with_underscore.yaml
+	mkdir test_directory_with_underscore
+
+	# Stage the created files and directories
+	git add .
+}
+
+teardown() {
+	# Remove the temporary directory and all of its contents
+	rm -rf "$TEMP_DIR"
+	# Return to the original directory
+	cd "$INITIAL_DIR" || exit
+}
+
+@test "Check if underscores in filenames are replaced with dashes" {
+	# Run the pre-commit script using the initial directory to get the correct path
+	"$INITIAL_DIR"/.hooks/check-underscores-in-name.sh
+
+	# Check if files with dashes exist and are staged
+	[ -f test-file-with-underscore.yaml ]
+	git diff --cached --name-only | grep "test-file-with-underscore.yaml"
+}
+
+@test "Check if old filenames with underscores are not staged" {
+	# Run the pre-commit script
+	"$INITIAL_DIR"/.hooks/check-underscores-in-name.sh
+
+	# Check if the old filenames/directories with underscores are not staged
+	run git diff --cached --name-only
+	[[ "$output" != *"test_file_with_underscore.yaml"* ]]
+
+	run git diff --cached --name-only
+	[[ "$output" != *"test_directory_with_underscore"* ]]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: script-must-have-extension
         name: Ensure shell scripts end with .sh
         types: [shell]
-        exclude: ^templates/
+        exclude: ^templates/|^.hooks/tests/
       - id: shfmt
         exclude: ^templates/
       # Configuration in .mdlrc and .hooks/linters/mdstyle.rb
@@ -47,7 +47,7 @@ repos:
       - id: codespell
         entry: |
           codespell -q 3 -f
-          -S ".git,.github,README.md,docs/*,go.sum,*test.go,ttps/macOS/swiftbelt_exec/SwiftBelt.swift"
+          -S ".git,.github,README.md,docs/*,go.sum,*test.go,*SwiftBelt.swift"
 
   - repo: local
     hooks:
@@ -56,3 +56,8 @@ repos:
         language: script
         entry: .hooks/go-copyright.sh
         files: '\.go$'
+
+      - id: check-underscores-in-name
+        name: Ensure all committed directories and YAML files are uniform
+        language: script
+        entry: .hooks/check-underscores-in-name.sh


### PR DESCRIPTION
# Proposed Changes

Implemented a git pre-commit hook that enforces a naming convention for YAML files and directories. The hook ensures that any committed YAML files or directories with underscores in their names are automatically renamed to use dashes. This change also includes BATS tests to validate the functionality of the hook.

## Related Issue(s)

N/A

## Testing

1. Created a BATS test suite that verifies:
    - If underscores in filenames are correctly replaced with dashes.
    - If old filenames with underscores are not staged after the renaming.
   
1. Manual testing by staging files and directories with underscores and observing the changes post-hook execution.

## Documentation

The script itself has inline comments detailing its purpose and functionality. No additional external documentation has been provided.

## Screenshots/GIFs (optional)

N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [x] 🚀