### PR TITLE
Added Tactic TA0043 Reconnaissance with procedure T1595.001 Active Scanning: Scan IP Blocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         entry: yamllint --strict -c .hooks/linters/yamllint.yaml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.2
+    rev: v3.0.3
     hooks:
       - id: prettier
         files: \.(json|yaml|yml)$

--- a/ttps/reconnaissance/active-scanning/README.md
+++ b/ttps/reconnaissance/active-scanning/README.md
@@ -1,0 +1,52 @@
+# Scan IP Blocks
+
+![Community TTP - sw8y](https://img.shields.io/badge/Community_TTP-green)
+
+Perform a syn scan against a range of IP addresses.
+
+## Arguments
+
+* ip_range (type=str): A range of IP addresses to be scanned. This range can be provided in CIDR notation (e.g, 10.0.0.0/16)
+* ports (type=str): Ports to be scanned for on each IP address. If this parameter is not provided, the default port list
+will be scanned.    
+    * default ports: 20,21,22,23,25,53,80,110,125,143,443,587,2525,3306,3389
+* cleanup (type=bool): true or false. Determines whether or not the Nmap scanner will be uninstalled after execution. By default,
+the scanner is removed.
+
+
+- **cleanup**: Removes the Nmap scanner from the local system.
+
+## Pre-requisites
+
+Ensure that you have the necessary package manager for your system:
+* APT for Linux
+* Brew for Mac
+
+## Examples
+
+Execute port scans against a supplied IP address block. Once execution is
+complete, this TTP will uninstall the nmap scanner.
+
+Scanning on the ports provided as an argument
+    ```bash
+    ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.244/32 --arg ports=80
+    ```
+
+Scanning the list of default ports
+    ```bash
+        ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.0/24
+    ```
+
+Scanning the list of default ports and NOT uninstalling the nmap scanner 
+    ```bash
+        ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.0/24 --arg cleanup=false
+    ```
+## Steps
+
+1. **confirm-required-tools-installed**: Identifies the operating system and confirms that the appropriate package manager
+is installed. After, checks to confirm that the nmap scanner is installed. If not, the scanner will be installed.
+
+1. **run-scan**: Runs the nmap scanner against the supplied IP address block and prints the results to stdout.
+
+1. **Cleanup**: Removes the nmap scanner from the local system if the cleanup argument is set to true. By default, the scanner
+will not be removed.

--- a/ttps/reconnaissance/active-scanning/README.md
+++ b/ttps/reconnaissance/active-scanning/README.md
@@ -7,19 +7,23 @@ Perform a syn scan against a range of IP addresses.
 ## Arguments
 
 * ip_range (type=str): A range of IP addresses to be scanned. This range can be provided in CIDR notation (e.g, 10.0.0.0/16)
-* ports (type=str): Ports to be scanned for on each IP address. If this parameter is not provided, the default port list
-will be scanned.
-    * default ports: 20,21,22,23,25,53,80,110,125,143,443,587,2525,3306,3389
-* cleanup (type=bool): true or false. Determines whether or not the Nmap scanner will be uninstalled after execution. By default,
-the scanner is removed.
 
+* ports (type=str): Ports to be scanned for on each IP address. If this parameter is not provided, the default port list
+
+will be scanned. Default ports: 20,21,22,23,25,53,80,110,125,143,443,587,2525,3306,3389
+
+* cleanup (type=bool): true or false. Determines whether or not the Nmap scanner will be
+
+uninstalled after execution. By default, the scanner is removed.
 
 - **cleanup**: Removes the Nmap scanner from the local system.
 
 ## Pre-requisites
 
 Ensure that you have the necessary package manager for your system:
+
 * APT for Linux
+
 * Brew for Mac
 
 ## Examples
@@ -28,25 +32,32 @@ Execute port scans against a supplied IP address block. Once execution is
 complete, this TTP will uninstall the nmap scanner.
 
 Scanning on the ports provided as an argument
-    ```bash
-    ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.244/32 --arg ports=80
-    ```
+
+```bash
+./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml \
+--arg ip_range=10.0.0.244/32 --arg ports=80
+```
 
 Scanning the list of default ports
-    ```bash
-        ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.0/24
-    ```
+
+```bash
+./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml \
+--arg ip_range=10.0.0.0/24
+```
 
 Scanning the list of default ports and NOT uninstalling the nmap scanner
-    ```bash
-        ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.0/24 --arg cleanup=false
-    ```
+
+```bash
+./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml \
+--arg ip_range=10.0.0.0/24 --arg cleanup=false
+```
+
 ## Steps
 
 1. **confirm-required-tools-installed**: Identifies the operating system and confirms that the appropriate package manager
-is installed. After, checks to confirm that the nmap scanner is installed. If not, the scanner will be installed.
+    is installed. After, checks to confirm that the nmap scanner is installed. If not, the scanner will be installed.
 
 1. **run-scan**: Runs the nmap scanner against the supplied IP address block and prints the results to stdout.
 
 1. **Cleanup**: Removes the nmap scanner from the local system if the cleanup argument is set to true. By default, the scanner
-will not be removed.
+    will not be removed.

--- a/ttps/reconnaissance/active-scanning/README.md
+++ b/ttps/reconnaissance/active-scanning/README.md
@@ -8,7 +8,7 @@ Perform a syn scan against a range of IP addresses.
 
 * ip_range (type=str): A range of IP addresses to be scanned. This range can be provided in CIDR notation (e.g, 10.0.0.0/16)
 * ports (type=str): Ports to be scanned for on each IP address. If this parameter is not provided, the default port list
-will be scanned.    
+will be scanned.
     * default ports: 20,21,22,23,25,53,80,110,125,143,443,587,2525,3306,3389
 * cleanup (type=bool): true or false. Determines whether or not the Nmap scanner will be uninstalled after execution. By default,
 the scanner is removed.
@@ -37,7 +37,7 @@ Scanning the list of default ports
         ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.0/24
     ```
 
-Scanning the list of default ports and NOT uninstalling the nmap scanner 
+Scanning the list of default ports and NOT uninstalling the nmap scanner
     ```bash
         ./ttpforge run ../ForgeArmory/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml --arg ip_range=10.0.0.0/24 --arg cleanup=false
     ```

--- a/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml
+++ b/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml
@@ -1,0 +1,92 @@
+---
+name: Scan IP Address Blocks
+description: |
+  This TTP conducts scans against a range of IP addresses to identify alive hosts and open ports
+mitre:
+  tactics:
+    - TA0043 Reconnaissance
+  techniques:
+    - T1595 Active Scanning
+  subtechniques:
+    - "T1595.001 Active Scanning: Scanning IP Blocks"
+
+args:
+  - name: ip_range
+    type: string
+  - name: ports
+    type: string
+    default: 20,21,22,23,25,53,80,110,125,143,443,587,2525,3306,3389
+  - name: cleanup
+    type: bool
+    default: true
+
+steps:
+
+  - name: confirm-required-tools-installed
+    inline: |
+      # Determine the operating system
+      OS=$(uname)
+      if [[ "$OS" == "Darwin" ]]; then
+
+      # Confirm that brew package manager is installed
+        if ! command -v brew &> /dev/null; then
+          echo "===> Error: Brew package manager is not installed on the current system. Please install to proceed."
+        else
+          echo "===> Confirmed: Brew is installed."
+
+          # Confirm that nmap utility is installed. If not, install it.
+          if ! command -v nmap &> /dev/null; then
+            echo "===> Error: Nmap is not installed on the current system. Installing now."
+            brew install nmap
+          else
+            echo "===> Confirmed: Nmap is installed."
+          fi
+        fi
+      elif [[ "$OS" == "Linux" ]]; then
+
+        # Confirm that apt package manager is installed
+        if ! command -v apt &> /dev/null; then
+          echo "===> Error: Apt package manager is not installed on the current system. Please install to proceed."
+        else
+          echo "===> Apt is installed."
+
+          # Confirm that nmap utility is installed. If not, install it.
+          if ! command -v nmap &> /dev/null; then
+            echo "===> Error: Nmap is not installed on the current system. Installing now."
+            apt install nmap -y
+          else
+            echo "===> Confirmed: Nmap is installed."
+          fi
+        fi
+      else
+        echo "Unsupported operating system."
+        exit 1
+
+      fi
+
+  - name: run-scan
+    inline: |
+      echo "IP range: {{ .Args.ip_range }}"
+      echo "Port(s) to be scanned: {{ .Args.ports }}"
+      sudo nmap -sS -sV -Pn {{.Args.ip_range}} -p {{.Args.ports}}
+      echo "[+] DONE!"
+
+    cleanup:
+      inline: |
+        # Remove Nmap scanner
+        OS=$(uname)
+        if [[ "{{ .Args.cleanup }}" == true ]]; then
+          echo "===> Uninstalling Nmap scanner..."
+          if [[ "$OS" == "Darwin" ]]; then
+            echo "===> Uninstalling Nmap"
+            brew uninstall nmap
+            echo "[+] DONE!"
+
+          elif [[ "$OS" == "Linux" ]]; then
+            echo "===> Uninstalling Nmap"
+            apt uninstall nmap -y
+            echo "[+] DONE!"
+
+          fi
+        fi
+

--- a/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml
+++ b/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml
@@ -73,22 +73,18 @@ steps:
 
     cleanup:
       inline: |
-
         # Remove Nmap scanner
         OS=$(uname)
-        if [[ "{{ .Args.cleanup }}" == true ]]; then
-          echo "===> Uninstalling Nmap scanner..."
+        echo "===> Uninstalling Nmap scanner..."
 
-          if [[ "$OS" == "Darwin" ]]; then
-            echo "===> Uninstalling Nmap"
-            brew uninstall nmap
-            echo "[+] DONE!"
+        if [[ "$OS" == "Darwin" ]]; then
+          echo "===> Uninstalling Nmap"
+          brew uninstall nmap
+          echo "[+] DONE!"
 
-          elif [[ "$OS" == "Linux" ]]; then
-            echo "===> Uninstalling Nmap"
-            apt uninstall nmap -y
-            echo "[+] DONE!"
-
-          fi
+        elif [[ "$OS" == "Linux" ]]; then
+          echo "===> Uninstalling Nmap"
+          apt uninstall nmap -y
+          echo "[+] DONE!"
         fi
         echo "===> Cleanup complete!"

--- a/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml
+++ b/ttps/reconnaissance/active-scanning/scanning-ip-blocks.yaml
@@ -21,14 +21,13 @@ args:
     default: true
 
 steps:
-
   - name: confirm-required-tools-installed
     inline: |
       # Determine the operating system
       OS=$(uname)
       if [[ "$OS" == "Darwin" ]]; then
 
-      # Confirm that brew package manager is installed
+        # Confirm that brew package manager is installed
         if ! command -v brew &> /dev/null; then
           echo "===> Error: Brew package manager is not installed on the current system. Please install to proceed."
         else
@@ -42,6 +41,7 @@ steps:
             echo "===> Confirmed: Nmap is installed."
           fi
         fi
+
       elif [[ "$OS" == "Linux" ]]; then
 
         # Confirm that apt package manager is installed
@@ -58,10 +58,10 @@ steps:
             echo "===> Confirmed: Nmap is installed."
           fi
         fi
+
       else
         echo "Unsupported operating system."
-        exit 1
-
+        exit 27
       fi
 
   - name: run-scan
@@ -73,10 +73,12 @@ steps:
 
     cleanup:
       inline: |
+
         # Remove Nmap scanner
         OS=$(uname)
         if [[ "{{ .Args.cleanup }}" == true ]]; then
           echo "===> Uninstalling Nmap scanner..."
+
           if [[ "$OS" == "Darwin" ]]; then
             echo "===> Uninstalling Nmap"
             brew uninstall nmap
@@ -89,4 +91,4 @@ steps:
 
           fi
         fi
-
+        echo "===> Cleanup complete!"


### PR DESCRIPTION
# Proposed Changes

Created a TTP for scanning IP blocks using the Nmap utility. This TTP will check the OS of the computer, then confirm that the appropriate package manager is also installed. If confirmed, the system will be checked to see if nmap is installed and install it if not. 

## Related Issue(s)

No issues identified.

## Testing

1. Verified the results of "uname" on the local system.
2. Run TTP with nmap installed to verify functionality.
3. Run TTP without nmap insatlled to verify install.
4. Run TTP without port list to verify default ports are scanned.
5. Run TTP with port list to verify that the provided list of ports are scanned.
6. Run TTP with cleanup option set to false to verify that nmap is not uninstalled.
7. Run TTP with cleanup option set to true to verify that nmap is uninstalled.

## Documentation

README.md has been updated to reflect what this TTP does and how it operates.

## Screenshots/GIFs (optional)

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [x] 🚀
