### PR TITLE
Update detections to use us-east-1 specifically

### DIFF
--- a/ttps/cloud/aws/iam/enumerate-iam/README.md
+++ b/ttps/cloud/aws/iam/enumerate-iam/README.md
@@ -75,3 +75,10 @@ ttpforge run forgearmory//cloud/aws/iam/enumerate-iam/enumerate-iam.yaml \
    for specific API calls in the CloudTrail logs within a certain time
    window. If it finds more than a threshold number of calls from the same IP
    address, it will raise an alert.
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0007 Discovery
+- **Techniques**:
+  - T1082 System Information Discovery

--- a/ttps/cloud/aws/iam/enumerate-iam/enumerate-iam.yaml
+++ b/ttps/cloud/aws/iam/enumerate-iam/enumerate-iam.yaml
@@ -144,7 +144,9 @@ steps:
         for api_call in "${API_CALLS[@]}"; do
           EVENTS=$(aws cloudtrail lookup-events \
             --lookup-attributes AttributeKey=EventName,AttributeValue=$api_call \
-            --start-time $START_TIME --end-time $END_TIME)
+            --start-time $START_TIME \
+            --end-time $END_TIME \
+            --region us-east-1)
 
           # Check if api_call event exists in the events
           if echo "$EVENTS" | jq -e '.Events[] | select(.EventName=="'$api_call'")' > /dev/null; then

--- a/ttps/cloud/aws/iam/enumerate-iam/enumerate-iam.yaml
+++ b/ttps/cloud/aws/iam/enumerate-iam/enumerate-iam.yaml
@@ -11,6 +11,11 @@ args:
     default: /tmp/enumerate-iam
   - name: extended_scan
     default: false
+mitre:
+  tactics:
+    - TA0007 Discovery
+  techniques:
+    - T1082 System Information Discovery
 
 steps:
   - name: ensure-aws-creds-present

--- a/ttps/cloud/aws/iam/revive-old-iam-user/README.md
+++ b/ttps/cloud/aws/iam/revive-old-iam-user/README.md
@@ -64,3 +64,10 @@ ttpforge run forgearmory//cloud/aws/iam/revive-old-iam-user/revive-old-iam-user.
 1. **Check Detection**: If `detect` is true, query cloudtrail to
    see if the TTP was logged. This step checks for recent `CreateAccessKey`
    and `GenerateDataKey` events.
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0003 Persistence
+- **Techniques**:
+  - T1098 Account Manipulation

--- a/ttps/cloud/aws/iam/revive-old-iam-user/revive-old-iam-user.yaml
+++ b/ttps/cloud/aws/iam/revive-old-iam-user/revive-old-iam-user.yaml
@@ -113,7 +113,9 @@ steps:
         for event_name in "${EVENT_NAMES[@]}"; do
             EVENTS=$(aws cloudtrail lookup-events \
                 --lookup-attributes AttributeKey=EventName,AttributeValue=$event_name \
-                --start-time $START_TIME --end-time $END_TIME)
+                --start-time $START_TIME \
+                --end-time $END_TIME \
+                --region us-east-1)
 
             # If there are recent events
             if [[ "$(echo "$EVENTS" | jq -r '.Events | length')" -gt 0 ]]; then

--- a/ttps/cloud/aws/iam/revive-old-iam-user/revive-old-iam-user.yaml
+++ b/ttps/cloud/aws/iam/revive-old-iam-user/revive-old-iam-user.yaml
@@ -5,6 +5,11 @@ args:
   - name: detect
     default: true
   - name: user
+mitre:
+  tactics:
+    - TA0003 Persistence
+  techniques:
+    - T1098 Account Manipulation
 
 steps:
   - name: ensure-aws-creds-present

--- a/ttps/cloud/aws/secretsmanager/steal-secretsmanager-secret/README.md
+++ b/ttps/cloud/aws/secretsmanager/steal-secretsmanager-secret/README.md
@@ -62,3 +62,10 @@ ttpforge run forgearmory//cloud/aws/secretsmanager/steal-secretsmanager-secret/s
    for specific API calls in the CloudTrail logs within a certain time
    window. If it finds specific API calls (GetSecretValue, ListSecrets)
    from the same IP address, it will output the details.
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0009 Collection
+- **Techniques**:
+  - T1213 Data from Information Repositories

--- a/ttps/cloud/aws/secretsmanager/steal-secretsmanager-secret/steal-secretsmanager-secret.yaml
+++ b/ttps/cloud/aws/secretsmanager/steal-secretsmanager-secret/steal-secretsmanager-secret.yaml
@@ -1,7 +1,6 @@
 ---
 name: steal-secretsmanager-secret
 description: |
-
   Determine what permissions an IAM role has through
   brute force using the
   [enumerate-iam](https://github.com/andresriancho/enumerate-iam) tool.
@@ -11,6 +10,11 @@ args:
   - name: target_secret_id
   - name: artifact_output_dir
     default: $HOME/.ttpforge/artifacts/steal-secretsmanager-secret
+mitre:
+  tactics:
+    - TA0009 Collection
+  techniques:
+    - T1213 Data from Information Repositories
 
 steps:
   - name: ensure-aws-creds-present

--- a/ttps/cloud/aws/secretsmanager/steal-secretsmanager-secret/steal-secretsmanager-secret.yaml
+++ b/ttps/cloud/aws/secretsmanager/steal-secretsmanager-secret/steal-secretsmanager-secret.yaml
@@ -113,7 +113,8 @@ steps:
           EVENTS=$(aws cloudtrail lookup-events \
               --lookup-attributes AttributeKey=EventName,AttributeValue=$api_call \
               --start-time $START_TIME \
-              --end-time $END_TIME)
+              --end-time $END_TIME \
+              --region us-east-1)
 
           if echo "$EVENTS" | jq -e '.Events[] | select(.EventName=="'$api_call'")' > /dev/null; then
               echo "EventTime EventName SecretId EventSource Region AccessKeyId SourceIPAddress"


### PR DESCRIPTION
# Proposed Changes

- Updated detections for cloud TTPs to use us-east-1. This will allow us to minimize false negatives.
- Added missing MITRE mappings to cloud TTPs and docs

## Related Issue(s)

N/A

## Testing

Tested all affected TTPs.

## Documentation

N/A

## Screenshots/GIFs (optional)

N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [x] 🚀
