### PR TITLE
Removed problematic colon in 4 macOS TTPs

### DIFF
--- a/ttps/cred-and-key-mgmt/macos/prompt-api/prompt-api.yaml
+++ b/ttps/cred-and-key-mgmt/macos/prompt-api/prompt-api.yaml
@@ -8,7 +8,7 @@ mitre:
     - T1059 Command and Scripting Interpreter
     - TA0006 Credential Access
   techniques:
-    - T1059.002 Command and Scripting Interpreter: AppleScript
+    - T1059.002 Command and Scripting Interpreter AppleScript
 steps:
   - name: prompt-api
     inline: |

--- a/ttps/cred-and-key-mgmt/macos/prompt-cli/prompt-cli.yaml
+++ b/ttps/cred-and-key-mgmt/macos/prompt-cli/prompt-cli.yaml
@@ -7,7 +7,7 @@ mitre:
     - T1059 Command and Scripting Interpreter
     - TA0006 Credential Access
   techniques:
-    - T1059.002 Command and Scripting Interpreter: AppleScript
+    - T1059.002 Command and Scripting Interpreter AppleScript
 args:
   - name: detect
     default: true

--- a/ttps/discovery-and-collection/macos/swiftspy-exec/swiftspy-exec.yaml
+++ b/ttps/discovery-and-collection/macos/swiftspy-exec/swiftspy-exec.yaml
@@ -8,7 +8,7 @@ mitre:
   techniques:
     - T1056 Input Capture
   subtechniques:
-    - T1056.001 Input Capture: Keylogging
+    - T1056.001 Input Capture Keylogging
 steps:
   - name: swiftspy-exec
     inline: |

--- a/ttps/persistence/macos/loginitem/loginitem.yaml
+++ b/ttps/persistence/macos/loginitem/loginitem.yaml
@@ -14,7 +14,7 @@ mitre:
   techniques:
     - T1547 Boot or Logon Autostart Execution
   subtechniques:
-    - T1547.015 Boot or Logon Autostart Execution: Login Items
+    - T1547.015 Boot or Logon Autostart Execution Login Items
 steps:
   - name: loginitem
     inline: |


### PR DESCRIPTION
Modified 4 macOS TTPs that no longer worked with a recent version of  ttpforge due to improper use within the TTP yaml file of the colon symbol. Simply removed those instances.

# Proposed Changes

Removed the extra colon under the subtechniques section of the following macOS TTPs:

1. cred-and-key-mgt/macos/prompt-api.yaml
2. cred-and-key-mgt/macos/prompt-cli.yaml
3. discovery-and-collection/macos/swiftspy-exec/swiftspy-exec.yaml
4. persistence/macos/loginitem/loginitem.yaml

## Related Issue(s)

N/A

## Testing

Re-rean each of the 4 affected TTPs above and confirmed successful TTP execution with no errors.

## Documentation

N/A

## Screenshots/GIFs (optional)

<!--- Include screenshots or GIFs to showcase your changes,
especially for UI updates -->

## Checklist

- [ ] Ran `mage runprecommit` locally and fixed any issues that arose.
- [ ] Curated your commit(s) so they are legible and easy to read and understand.
- [ ] 🚀
