### PR TITLE
Removing colon from subtechnique descriptor in 4 macOS TTPs, which effectively breaks the TTP.

### DIFF
--- a/ttps/cred-and-key-mgmt/macos/prompt-api/prompt-api.yaml
+++ b/ttps/cred-and-key-mgmt/macos/prompt-api/prompt-api.yaml
@@ -8,7 +8,7 @@ mitre:
     - T1059 Command and Scripting Interpreter
     - TA0006 Credential Access
   techniques:
-    - T1059.002 Command and Scripting Interpreter: AppleScript
+    - T1059.002 Command and Scripting Interpreter AppleScript
 steps:
   - name: prompt-api
     inline: |

--- a/ttps/cred-and-key-mgmt/macos/prompt-cli/prompt-cli.yaml
+++ b/ttps/cred-and-key-mgmt/macos/prompt-cli/prompt-cli.yaml
@@ -7,7 +7,7 @@ mitre:
     - T1059 Command and Scripting Interpreter
     - TA0006 Credential Access
   techniques:
-    - T1059.002 Command and Scripting Interpreter: AppleScript
+    - T1059.002 Command and Scripting Interpreter AppleScript
 args:
   - name: detect
     default: true

--- a/ttps/discovery-and-collection/macos/swiftspy-exec/swiftspy-exec.yaml
+++ b/ttps/discovery-and-collection/macos/swiftspy-exec/swiftspy-exec.yaml
@@ -8,7 +8,7 @@ mitre:
   techniques:
     - T1056 Input Capture
   subtechniques:
-    - T1056.001 Input Capture: Keylogging
+    - T1056.001 Input Capture Keylogging
 steps:
   - name: swiftspy-exec
     inline: |

--- a/ttps/persistence/macos/loginitem/loginitem.yaml
+++ b/ttps/persistence/macos/loginitem/loginitem.yaml
@@ -14,7 +14,7 @@ mitre:
   techniques:
     - T1547 Boot or Logon Autostart Execution
   subtechniques:
-    - T1547.015 Boot or Logon Autostart Execution: Login Items
+    - T1547.015 Boot or Logon Autostart Execution Login Items
 steps:
   - name: loginitem
     inline: |


### PR DESCRIPTION
Summary: Removing the colong from the subtechnique descriptor in for macOS TTPs, which effectively breaks the TTP.

Reviewed By: d3sch41n

Differential Revision: D51114590


