### PR TITLE
Fix edit_step backup working directory handling

### DIFF
--- a/ttps/examples/steps/edit-step/edit-step.yaml
+++ b/ttps/examples/steps/edit-step/edit-step.yaml
@@ -10,7 +10,7 @@ steps:
       cat file-to-edit.txt
   - name: edit-target-file
     edit_file: "file-to-edit.txt"
-    backup_file: "/tmp/my-backup.txt"
+    backup_file: "my-backup.txt"
     edits:
       - old: REPLACE_ME
         new: REPLACED_BY_EDIT
@@ -20,14 +20,9 @@ steps:
       - old: (?P<fn_call>(?ms:^another_multline_function_call\(.*?\)$))
         new: "/*${fn_call}*/"
         regexp: true
+    cleanup:
+      inline: mv my-backup.txt file-to-edit.txt
   - name: target-file-post-edit
     inline: |
-      set -e
-
-      echo -e "Target file post-edit:"
-      cat $HOME/.ttpforge/repos/forgearmory/ttps/examples/steps/edit-step/file-to-edit.txt
-    cleanup:
-      inline: |
-        set -e
-
-        mv /tmp/my-backup.txt $HOME/.ttpforge/repos/forgearmory/ttps/examples/steps/edit-step/file-to-edit.txt
+      echo "File contents after edit:"
+      cat file-to-edit.txt


### PR DESCRIPTION
Summary:
Fix `edit_step` to make `backup_file` also use `FetchAbs` just like the target file.

Update example in `ForgeArmory` to reflect new behavior

I think this was actually ok once we switched back to doing a top-level directory change in RunSteps, but either way it is better to have this redundancy.

Differential Revision: D51307671


