### PR TITLE
Modified one of the publicly commmitted macOS TTPs (sshkeygen-load-dylib.yaml), which was generating a ttpforge error due to a non zero exit code.

### DIFF
--- a/ttps/defense-evasion/macos/sshkeygen-load-dylib/sshkeygen-load-dylib.yaml
+++ b/ttps/defense-evasion/macos/sshkeygen-load-dylib/sshkeygen-load-dylib.yaml
@@ -18,7 +18,7 @@ steps:
   - name: load-dylib
     inline: |
       echo "Next, loading the compiled dylib via ssh-keygen..."
-      ssh-keygen -D `pwd`/calc.dylib
+      ssh-keygen -D `pwd`/calc.dylib || echo "Overwriting exit status code. exited with status: $?"
       echo "TTP Done!"
     cleanup:
       inline: |


### PR DESCRIPTION
Summary: Modified one of the publicly committed macOS TTPs to resolve a non-zero exit code error from the ssh-keygen binary used in the TTP.

Reviewed By: l50

Differential Revision: D51721160


