### PR TITLE
Added Kubernetes TTP helpers; fixed bugs in docs

### DIFF
--- a/ttps/cloud/aws/s3/bucket-enum/README.md
+++ b/ttps/cloud/aws/s3/bucket-enum/README.md
@@ -42,13 +42,14 @@ Run the TTP using a wordlist from the [SecLists repo](https://github.com/danielm
 
 ```bash
 ttpforge run forgearmory//cloud/aws/s3/bucket-enum/bucket-enum.yaml \
-    --arg bucket_list=/data/users/jaysong/fbsource/fbcode/security/redteam/purple_team/ForgeArmory/SecLists/Usernames/top-usernames-shortlist.txt \
+    --arg bucket_list=~/SecLists/Usernames/top-usernames-shortlist.txt \
     --arg create_bucket_list=false
 ```
 
 ## Steps
 
-1. **AWS Connector**: This step validates the necessary AWS credentials and region settings for the TTP.
+1. **AWS Connector**: This step validates the necessary AWS credentials and
+   region settings for the TTP.
 
 1. **Create Bucket List**: If `create_bucket_list` is set to `true`, this
    step will create a file specified by the `bucket_list` argument and populate
@@ -59,7 +60,8 @@ ttpforge run forgearmory//cloud/aws/s3/bucket-enum/bucket-enum.yaml \
 1. **Provision**: This step installs the necessary tools for bucket enumeration,
    specifically the S3Scanner tool.
 
-1. **Bucket Discovery**: This step discovers S3 buckets using the S3Scanner tool.
+1. **Bucket Discovery**: This step discovers S3 buckets using the S3Scanner
+   tool.
 
 1. **Check Detection**: If `detect` is set to `true`, this
    step will look for

--- a/ttps/helpers/containers/k8s/setup-kubeconfig-for-eks.yaml
+++ b/ttps/helpers/containers/k8s/setup-kubeconfig-for-eks.yaml
@@ -1,0 +1,27 @@
+---
+name: setup-kubeconfig-for-eks
+description: |
+  This helper sets up kubeconfig for an Amazon EKS cluster.
+  It uses the AWS CLI to update the kubeconfig file with the necessary configuration to connect to the EKS cluster.
+args:
+  - name: cluster_name
+    description: Name of the Amazon EKS cluster
+    required: true
+  - name: cluster_region
+    description: AWS region where the EKS cluster is located
+    default: "us-west-2"
+requirements:
+  platforms:
+    - os: linux
+    - os: darwin
+
+steps:
+  - name: update-kubeconfig
+    description: "Update kubeconfig for the EKS cluster."
+    inline: |
+      aws eks update-kubeconfig --region {{ .Args.cluster_region }} --name {{ .Args.cluster_name }}
+      if [ "$?" -ne 0 ]; then
+        echo "Failed to update kubeconfig for EKS cluster" >&2
+        exit 1
+      fi
+      echo "Kubeconfig updated successfully for EKS cluster: {{ .Args.cluster_name }}"

--- a/ttps/helpers/containers/k8s/valid-k8s-env-configured.yaml
+++ b/ttps/helpers/containers/k8s/valid-k8s-env-configured.yaml
@@ -1,0 +1,52 @@
+---
+name: validate-kubernetes-env-configured
+description: |
+  This helper is designed to validate the necessary Kubernetes configuration for TTPForge.
+  It checks for the presence of the kubectl command and the current kubeconfig context.
+  It also allows the user to specify the Kubernetes context to be used with TTPForge.
+args:
+  - name: context
+    description: Name of the Kubernetes context to use with TTPForge
+    default: ""
+
+steps:
+  - name: ensure-kubectl-present
+    description: "Ensure kubectl is installed."
+    inline: |
+      if ! [ -x "$(command -v kubectl)" ]; then
+        echo 'Error: kubectl is not installed.' >&2
+        exit 1
+      else
+        echo -e "kubectl is installed: $(kubectl version --client --short)"
+      fi
+
+  - name: ensure-kubeconfig-context
+    description: "Ensure a valid kubeconfig context is set."
+    inline: |
+      if [[ -z "${KUBECONFIG}" && -z "${HOME}/.kube/config" ]]; then
+        echo 'Error: KUBECONFIG environment variable is not set and default kubeconfig is not present.' >&2
+        exit 1
+      fi
+
+      if [[ -n "{{ .Args.context }}" ]]; then
+        echo "Setting Kubernetes context to {{ .Args.context }}."
+        kubectl config use-context "{{ .Args.context }}"
+      fi
+
+      CURRENT_CONTEXT=$(kubectl config current-context)
+      if [[ -z "${CURRENT_CONTEXT}" ]]; then
+        echo 'Error: No current Kubernetes context is set.' >&2
+        exit 1
+      else
+        echo -e "Current Kubernetes context is set to: ${CURRENT_CONTEXT}"
+      fi
+
+  - name: ensure-kubernetes-cluster-access
+    description: "Ensure access to the Kubernetes cluster."
+    inline: |
+      if ! kubectl get nodes &> /dev/null; then
+        echo 'Error: Cannot access the Kubernetes cluster with the current context.' >&2
+        exit 1
+      else
+        echo 'Successfully accessed the Kubernetes cluster.'
+      fi

--- a/ttps/helpers/git/download-latest-github-release.yaml
+++ b/ttps/helpers/git/download-latest-github-release.yaml
@@ -1,0 +1,63 @@
+---
+name: download-latest-github-release
+description: |
+  Downloads and extracts the latest release of a specified GitHub repository.
+args:
+  - name: repo_owner
+    description: The GitHub username of the repository owner.
+    required: true
+  - name: repo_name
+    description: The name of the GitHub repository.
+    required: true
+  - name: release_os
+    description: Release Operating System
+    type: string
+  - name: release_arch
+    description: Release Operating System
+    type: string
+requirements:
+  platforms:
+    - os: linux
+    - os: darwin
+
+steps:
+  - name: get_latest_release_info
+    description: Get the latest release information from GitHub.
+    inline: |
+      OS={{ .Args.release_os }}
+      ARCH={{ .Args.release_arch }}
+      REPO="https://api.github.com/repos/{{ .Args.repo_owner }}/{{ .Args.repo_name }}"
+      VERSION=$(curl -s "$REPO/releases/latest" | jq -r '.tag_name')
+      FILENAME="{{ .Args.repo_name }}_${VERSION}_${OS}_${ARCH}"
+      URL="$REPO/releases/latest/$FILENAME"
+      echo "{\"version\":\"$VERSION\",\"url\":\"$URL\",\"filename\":\"$FILENAME\"}"
+    outputs:
+      version:
+        filters:
+          - json_path: version
+      url:
+        filters:
+          - json_path: url
+      filename:
+        filters:
+          - json_path: filename
+
+  - name: download_and_extract
+    description: Download and extract the release archive or make the binary executable.
+    inline: |
+      FILENAME=$forge.steps.get_latest_release_info.outputs.filename
+      URL=$forge.steps.get_latest_release_info.outputs.url
+      echo "Downloading $FILENAME from $URL"
+      curl -sL $URL -o $FILENAME
+      if [[ $FILENAME == *.tar.gz ]]; then
+        echo "Extracting $FILENAME"
+        tar -xzf $FILENAME
+      elif [[ $FILENAME == *.zip ]]; then
+        echo "Extracting $FILENAME"
+        unzip $FILENAME
+      else
+        echo "Making $FILENAME executable"
+        chmod +x $FILENAME
+      fi
+
+      echo $FILENAME

--- a/ttps/privilege-escalation/suid-binary-escalation/README.md
+++ b/ttps/privilege-escalation/suid-binary-escalation/README.md
@@ -1,13 +1,18 @@
 # SUID Binary Privilege Escalation
 
-This TTP demonstrates how to use a SUID binary to escalate privileges. If no parameters outside of the low privileged user are provided, the TTP will create and execute a vulnerable scenario.
+This TTP demonstrates how to use a SUID binary to escalate privileges. If no
+parameters outside of the low privileged user are provided, the TTP will create
+and execute a vulnerable scenario.
 
 ## Arguments
 
-- **low_priv_user**: Low privileged user account to employ for privilege escalation. This argument is required
-- **target_bin**: Target SUID binary to employ for privilege escalation. Defaults to `/usr/bin/vim`.
+- **low_priv_user**: Low privileged user account to employ for privilege
+  escalation. This argument is required
+- **target_bin**: Target SUID binary to employ for privilege escalation.
+  Defaults to `/usr/bin/vim`.
 - **vuln_bin**: Filepath for the vulnerable bin. Defaults to `/usr/bin/vim-vuln`.
-- **escalation_params**: Parameters provided to the vulnerable bin to execute the privilege escalation. Defaults to `"-c ':silent !sudo whoami' -c 'qa'"`.
+- **escalation_params**: Parameters provided to the vulnerable bin to execute
+  the privilege escalation. Defaults to `"-c ':silent !sudo whoami' -c 'qa'"`.
 
 ## Requirements
 
@@ -22,7 +27,8 @@ To execute this TTP with the default parameters, you can use the following comma
 ttpforge run forgearmory//privilege-escalation/suid-binary-escalation/suid-binary-escalation.yaml --arg low_priv_user=demo_user
 ```
 
-This will attempt to escalate privileges using the default vulnerable binary `/usr/bin/vim-vuln` and parameters.
+This will attempt to escalate privileges using the default vulnerable
+binary `/usr/bin/vim-vuln` and parameters.
 
 ## MITRE ATT&CK Mapping
 
@@ -35,7 +41,15 @@ This will attempt to escalate privileges using the default vulnerable binary `/u
 
 ## Steps
 
-1. **Create Vulnerable Binary**: Copies the target binary to the specified vulnerable binary path.
-2. **Introduce Vulnerability**: Sets the SUID bit on the vulnerable binary to make it executable with elevated privileges.
-3. **Hunt for SUID Binaries**: Searches for SUID binaries in common binary directories.
-4. **Escalate Privilege**: Uses the vulnerable binary to escalate the privileges of the low privileged user and checks if the escalation was successful.
+1. **Create Vulnerable Binary**: Copies the target binary to the specified
+  vulnerable binary path.
+
+2. **Introduce Vulnerability**: Sets the SUID bit on the vulnerable binary to
+   make it executable with elevated privileges.
+
+3. **Hunt for SUID Binaries**: Searches for SUID binaries in common binary
+   directories.
+
+4. **Escalate Privilege**: Uses the vulnerable binary to escalate the
+   privileges of the low privileged user and checks if the escalation was
+   successful.


### PR DESCRIPTION
Summary:
**Added:**
- New Kubernetes setup and validation TTP helpers:
  - `setup-kubeconfig-for-eks.yaml`: Sets up kubeconfig for Amazon EKS clusters.
  - `valid-k8s-env-configured.yaml`: Validates Kubernetes config for TTPForge.
  - `download-latest-github-release.yaml`: Downloads the latest GitHub release.

**Changed:**
- Updated S3 bucket enumeration guide to improve clarity and usability.
  - Simplified `bucket_list` argument path in README.
  - Split steps descriptions into multiple lines for better readability.
- Introduced new formatting for privilege escalation README to enhance
  documentation readability and compliance with markdown best practices.

**Fixed:**
- Standardized numbering in S3 bucket enum README steps to ensure consistency.

Reviewed By: cedowens

Differential Revision: D54910544


