### PR TITLE
Increase TTP robustness

### DIFF
--- a/ttps/cloud/aws/ec2/create-unrestricted-security-group/README.md
+++ b/ttps/cloud/aws/ec2/create-unrestricted-security-group/README.md
@@ -22,7 +22,7 @@ across all ports and protocols.
   Default: nil
 
 - **wait_detect_time**: Time to wait for AWS GuardDuty to detect the event.
-  Default: 30
+  Default: 15
 
 ## Requirements
 

--- a/ttps/cloud/aws/ec2/create-unrestricted-security-group/create-unrestricted-security-group.yaml
+++ b/ttps/cloud/aws/ec2/create-unrestricted-security-group/create-unrestricted-security-group.yaml
@@ -90,17 +90,15 @@ steps:
 
         source "${aws_utils_path}"
 
-        SG_ID=$(aws ec2 describe-security-groups \
-          --filters Name=group-name,Values="{{ .Args.sg_name }}-*" \
-          --query "SecurityGroups[0].GroupId" --output text)
+        SG_IDS=$(aws ec2 describe-security-groups \
+          --filters Name=group-name,Values="{{ .Args.sg_name }}*" \
+          --query "SecurityGroups[*].GroupId" \
+          --output text)
 
-        if [[ -n "$SG_ID" && "$SG_ID" != "None" ]]; then
-          aws ec2 revoke-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 0-65535 --cidr 0.0.0.0/0
-          aws ec2 revoke-security-group-ingress --group-id "$SG_ID" --protocol udp --port 0-65535 --cidr 0.0.0.0/0
-          aws ec2 revoke-security-group-ingress --group-id "$SG_ID" --protocol icmp --port -1 --cidr 0.0.0.0/0
+        for SG_ID in $SG_IDS; do
           delete_security_groups "$SG_ID"
           echo "Deleted security group with ID: $SG_ID"
-        fi
+        done
 
   - name: wait-detection
     description: Give AWS GuardDuty and CloudTrail {{ .Args.wait_detect_time }} seconds to detect the event.


### PR DESCRIPTION
Summary:
**Changed:**

- Decreased the `wait_detect_time` default value from 30 to 15 seconds in the
  README.md and YAML files.
- Refactored the `cleanup` step in the YAML file to correctly handle multiple
  security group deletions:
  - Replaced the single `SG_ID` handling with a loop to iterate through
    multiple `SG_IDS`.
  - Updated the deletion logic to process each security group ID found by the
    `describe-security-groups` command.
  - Ensured all identified security groups are deleted by invoking the
    `delete_security_groups` function for each group ID.

Reviewed By: d0n601

Differential Revision: D58303180
