### PR TITLE
Software Installed on MacOS

### DIFF
--- a/ttps/discovery-and-collection/discover-macOS-software/README.md
+++ b/ttps/discovery-and-collection/discover-macOS-software/README.md
@@ -1,0 +1,72 @@
+# Discover Installed Software on MacOS
+
+![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+
+This TTP discovers software installed on a MacOS machine.
+
+## Arguments
+- **brew**:  a boolean flag specifying enumeration of software installed using brew
+- **mdfind**: a boolean flag specifying enumeration of software installed using mdfind
+- **sp**: a boolean flag specifying enumeration of software installed using system_profiler
+- **save**: a boolean flag set to save output to a file
+    Note: This argument can only be set with mdfind (output_mdfind.txt) or sp (output_sp.txt)
+
+## Pre-requisites
+- A linux-based or darwin-based operating system
+- Install necessary dependencies for arguments ie. brew
+- Bash shell
+
+## Examples
+You can run the TTP using the following example (after updating the arguments):
+```bash
+ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml
+```
+```bash
+ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
+--arg brew=true
+```
+```bash
+ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
+--arg mdfind=true
+```
+```bash
+ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
+--arg mdfind=true --arg save=true
+```
+```bash
+ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
+--arg sp=true
+```
+```bash
+ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
+--arg sp=true --arg save=true
+```
+
+## Steps
+1. **ls_applications_method** (default): This step uses ls to list software installed in the Applications directory.
+2. **brew_method**: This step enumerates software installed using brew.
+3. **mdfind_method**: This step enumerates software installed using mdfind.
+4. **system_profiler_method**: This step enumerates software installed using system_profiler.
+
+
+## Manual Reproduction Steps
+```bash
+# Discover installed software in the Applications directory.
+ls -la /Applications/
+
+# Discover installed software using brew.
+brew list
+
+# Discover installed software using mdfind.
+mdfind "kMDItemContentType == 'com.apple.application-bundle'"
+
+# Discover installed software using system_profiler.
+system_profiler SPApplicationsDataType
+
+```
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+    - TA0007 Discovery
+- **Techniques**:
+    - T1518 Software Discovery

--- a/ttps/discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml
+++ b/ttps/discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml
@@ -1,0 +1,70 @@
+---
+api_version: 2.0
+uuid: b33e7aff-b216-4ad9-8dd4-10a920e054c9
+name: MacOS Installed Software
+description: |
+  This TTP will list the installed software on your macOS machine; default: ls
+  There are three boolean arguments (brew, mdfind, sp (system profiler)) that can be utilized to specify different methods to showcase installed software.
+  Additionally, the save argument can be used to output results from mdfind or system profiler to a text file.
+
+requirements:
+  platforms:
+    - os: darwin
+mitre:
+  tactics:
+    - TA0007 Discovery
+  techniques:
+    - T1518 Software Discovery
+
+args:
+  - name: brew
+    description: list installed software via brew
+    type: bool
+    default: false
+
+  - name: mdfind
+    description: list installed software via mdfind
+    type: bool
+    default: false
+
+  - name: sp
+    description: list installed software via system_profiler
+    type: bool
+    default: false
+
+  - name: save
+    description: save software list to output.txt
+    type: bool
+    default: false
+
+steps:
+  {{if .Args.brew }}
+  - name: brew_method
+    description: Enumerating software installed using brew.
+    inline: brew list
+
+  {{else if .Args.mdfind }}
+  - name: mdfind_method
+    {{if .Args.save}}
+    description: Enumerating software installed using mdfind and saving output to output_mdfind.txt
+    inline: mdfind "kMDItemContentType == 'com.apple.application-bundle'" > output_mdfind.txt
+    {{else}}
+    description: Enumerating software installed using mdfind.
+    inline: mdfind "kMDItemContentType == 'com.apple.application-bundle'"
+    {{end}}
+
+  {{else if .Args.sp }}
+  - name: system_profiler_method
+      {{if .Args.save}}
+    description: Enumerating software installed using system_profiler and saving output to output_sp.txt
+    inline: system_profiler SPApplicationsDataType > output_sp.txt
+      {{else}}
+    description: Enumerating software installed using system_profiler.
+    inline: system_profiler SPApplicationsDataType
+      {{end}}
+
+  {{else}}
+  - name: ls_applications_method
+    description: Enumerating software installed in Application directory.
+    inline: ls -la /Applications/
+  {{end}}


### PR DESCRIPTION
Summary:
# Discover Installed Software on MacOS

![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)

This TTP discovers software installed on a MacOS machine.

## Arguments
- **brew**:  a boolean flag specifying enumeration of software installed using brew
- **mdfind**: a boolean flag specifying enumeration of software installed using mdfind
- **sp**: a boolean flag specifying enumeration of software installed using system_profiler
- **save**: a boolean flag set to save output to a file
    Note: This argument can only be set with mdfind (output_mdfind.txt) or sp (output_sp.txt)

## Pre-requisites
- A linux-based or darwin-based operating system
- Install necessary dependencies for arguments ie. brew
- Bash shell

## Examples 
You can run the TTP using the following example (after updating the arguments):
```bash
ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml
```
```bash
ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
--arg brew=true
```
```bash
ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
--arg mdfind=true
```
```bash
ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
--arg mdfind=true --arg save=true
```
```bash
ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
--arg sp=true 
```
```bash
ttpforge run forgearmory//discovery-and-collection/discover-macOS-software/discover-macOS-software.yaml \
--arg sp=true --arg save=true
```

## Steps
1. **ls_applications_method** (default): This step uses ls to list software installed in the Applications directory.
2. **brew_method**: This step enumerates software installed using brew.
3. **mdfind_method**: This step enumerates software installed using mdfind.
4. **system_profiler_method**: This step enumerates software installed using system_profiler.


## Manual Reproduction Steps
```bash
# Discover installed software in the Applications directory.
ls -la /Applications/

# Discover installed software using brew.
brew list

# Discover installed software using mdfind.
mdfind "kMDItemContentType == 'com.apple.application-bundle'"

# Discover installed software using system_profiler.
system_profiler SPApplicationsDataType

```
## MITRE ATT&CK Mapping

- **Tactics**:
    - TA0007 Discovery
- **Techniques**:
    - T1518 Software Discovery

Reviewed By: godlovepenn

Differential Revision: D61736451


