### PR TITLE
Windows Atomic Tests to TTP #8

### DIFF
--- a/ttps/collection/windows/screen-capture/README.md
+++ b/ttps/collection/windows/screen-capture/README.md
@@ -1,0 +1,34 @@
+# Windows Screen Capture (CopyFromScreen)
+
+![Meta TTP](https://img.shields.io/badge/Meta_TTP-blue)
+
+This TTP is designed to take a screen capture of the desktop through a call to the [Graphics.CopyFromScreen] .NET API.
+Graphics.CopyFromScreen]: https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen
+
+Derived from [Atomic Red Team T1113](https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1113/T1113.md#atomic-test-6---windows-screen-capture-copyfromscreen)
+
+## Arguments
+- **output**: a path variable specifying where captured results will be located. Default is $env:TEMP\T1113.png.
+
+## Pre-requisites
+- Windows operating system equipped with powershell
+
+## Examples
+You can run the TTP using the following example (after updating the arguments):
+```bash
+ttpforge run forgearmory//collection/windows/screen-capture/screen-capture.yaml
+```
+```bash
+ttpforge run forgearmory//collection/windows/screen-capture/screen-capture.yaml --arg output=png\TTP.png
+```
+
+## Steps
+1. **copy_from_screen** : This step takes a screen capture of the desktop
+2. **cleanup**: Deletes the screen capture that was created
+
+## MITRE ATT&CK Mapping
+
+- **Tactics**:
+    - TA0009 Collection
+- **Techniques**:
+    - T1113 Screen Capture

--- a/ttps/collection/windows/screen-capture/screen-capture.yaml
+++ b/ttps/collection/windows/screen-capture/screen-capture.yaml
@@ -1,0 +1,39 @@
+---
+api_version: 2.0
+uuid: 2e9c75ec-7ace-4d05-a652-fc7279de9362
+name: Windows Screen Capture (CopyFromScreen)
+description: |
+  Take a screen capture of the desktop through a call to the [Graphics.CopyFromScreen] .NET API.
+  Graphics.CopyFromScreen]: https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen
+  Derived from: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1113/T1113.md#atomic-test-6---windows-screen-capture-copyfromscreen
+
+requirements:
+  platforms:
+    - os: windows
+mitre:
+  tactics:
+    - TA0009 Collection
+  techniques:
+    - T1113 Screen Capture
+args:
+  - name: output
+    description: path where captured results will be placed
+    type: string
+    default: $env:TEMP\T1113.png
+
+steps:
+  - name: copy_from_screen
+    executor: powershell
+    inline: |
+      Add-Type -AssemblyName System.Windows.Forms
+      $screen = [Windows.Forms.SystemInformation]::VirtualScreen
+      $bitmap = New-Object Drawing.Bitmap $screen.Width, $screen.Height
+      $graphic = [Drawing.Graphics]::FromImage($bitmap)
+      $graphic.CopyFromScreen($screen.Left, $screen.Top, 0, 0, $bitmap.Size)
+      $bitmap.Save("{{.Args.output}}")
+    cleanup:
+      executor: powershell
+      inline: |
+        if (Test-Path "{{.Args.output}}"){
+          Remove-Item "{{.Args.output}}" -ErrorAction Ignore
+          }


### PR DESCRIPTION
Summary:
Converting atomics to ttps in Windows Atomic Red Team Tests
This ttp was 8/10 and it performs the follow function:
Create and start VirtualBox virtual machine
Take a screen capture of the desktop through a call to the [Graphics.CopyFromScreen] .NET API.
Graphics.CopyFromScreen]

Reviewed By: godlovepenn

Differential Revision: D62651150


