### PR TITLE
Update pkill to continue script

### DIFF
--- a/ttps/cred-and-key-mgmt/macos/dump-ff-cookies/dump-ff-cookies.yaml
+++ b/ttps/cred-and-key-mgmt/macos/dump-ff-cookies/dump-ff-cookies.yaml
@@ -16,8 +16,8 @@ steps:
       if [ -d /Applications/Firefox.app ]; then
          echo "[+] Firefox is installed...
          Attempting to kill Firefox and read from cookies.sqlite db..."
-         pkill -a -i "Firefox"
-         pkill -a -i "Firefox"
+         pkill -a -i "Firefox" || true
+         pkill -a -i "Firefox" || true
          osascript JXA-Firefox.js
          echo "[+] TTP Done!"
       else


### PR DESCRIPTION
Hi! Thanks for an outstanding framework ✨

I notice that when I run this TTP, it doesn't seem to run successfully whether or not Firefox is running. If Firefox is running, it closes but errors. When Firefox isn't running, it errors. I think it's because the pkill statement is returning status of 1 either on the first or second pkill call.

```
# firefox not running
% pkill -a -i "Firefox"
% echo $?
1
```

This PR adds `|| true` to tell the script to continue. I'm not sure why the second `pkill` is there but I added the same to both lines. This unblocks this locally for me.

# Proposed Changes

Prevents the script from stopping if Firefox is not running or has been killed.

## Related Issue(s)

None, but could make one if that helps.

## Testing

Manually tested on macos. Happy to contribute to specs.

## Documentation

Please point me in the right direction if this is needed.

## Checklist

- [ ] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commit(s) so they are legible and easy to read and understand.
- [ ] 🚀

